### PR TITLE
ci: Update CodeQL Action from v2 to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,6 @@ jobs:
         args: '-no-fail -fmt sarif -out results.sarif ./...'
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Update deprecated CodeQL Action from v2 to v3.

## Changes
- `.github/workflows/test.yml`: `codeql-action/upload-sarif@v2` → `@v3`

## Why
GitHub deprecated CodeQL Action v1/v2 as of January 10, 2025, causing gosec SARIF upload to fail on all PRs.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)