### PR TITLE
fix(ci): Align release workflow Go version with go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
-      - 'v*-rc*'
+      - "v*"
+      - "v*-rc*"
   workflow_dispatch:
 
 permissions:
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.21"
 
       - name: Build binary
         env:


### PR DESCRIPTION
## Summary
- Fixes Go version inconsistency between `go.mod` (1.21) and release workflow (was 1.22)
- Ensures release builds use the same Go version as development and CI testing

## Problem
The release workflow was configured to use Go 1.22 while `go.mod` specifies Go 1.21. This inconsistency could cause issues where:
- Features or syntax available only in 1.22 might accidentally be used in release builds
- Such code would pass release builds but fail in CI tests (which use 1.21)

## Changes
- Updated `.github/workflows/release.yml` to use `go-version: '1.21'` (matching go.mod)

## Test plan
- [ ] CI checks pass on this PR
- [ ] Release workflow still builds successfully

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)