### PR TITLE
ci: Add Dependabot for Go and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Go module dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "go"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` configuration file
- Configures automated dependency updates for Go modules (`gomod` ecosystem)
- Configures automated dependency updates for GitHub Actions (`github-actions` ecosystem)
- Weekly schedule (Mondays) for both ecosystems
- Appropriate labels for easy PR filtering

## Test plan
- [ ] Verify Dependabot configuration is valid (GitHub will validate on merge)
- [ ] Confirm Dependabot creates PRs for outdated dependencies after merging

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)